### PR TITLE
build: migrate Room from kapt to KSP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     kotlin("plugin.serialization")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 
@@ -63,6 +63,6 @@ dependencies {
     //Room
     val room_version = "2.5.1"
     implementation("androidx.room:room-runtime:$room_version")
-    kapt("androidx.room:room-compiler:$room_version")
+    ksp("androidx.room:room-compiler:$room_version")
     implementation("androidx.room:room-ktx:$room_version")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,5 +2,6 @@
 plugins {
     id("com.android.application") version "8.4.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.23" apply false
-    kotlin("plugin.serialization") version "1.9.0" apply false
+    kotlin("plugin.serialization") version "1.9.23" apply false
+    id("com.google.devtools.ksp") version "1.9.23-1.0.20" apply false
 }


### PR DESCRIPTION
## Changes
- Replace kotlin-kapt plugin with com.google.devtools.ksp
- Replace kapt() with ksp() for Room compiler
- Sync kotlin-serialization plugin version with Kotlin (1.9.23)

## Why
KSP is faster, officially recommended, and kapt is in maintenance mode.

## Checklist
- [x] Build passes
- [x] No functional changes

Closes #17