### PR TITLE
Fix critical bugs: JSON corruption, GlobalScope, duration

### DIFF
--- a/app/src/main/java/com/practicum/playlistmaker/new_playlist/data/PlayListRepositoryImpl.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/new_playlist/data/PlayListRepositoryImpl.kt
@@ -158,16 +158,9 @@ class PlayListRepositoryImpl(
 
         withContext(Dispatchers.IO) {
             val playlist = getPlaylist(playlistId)
-            appDatabase.playlistDao().updatePlaylist(
-                PlaylistEntity(
-                    playlist.playlistId.toInt(),
-                    playlist.playlistName,
-                    playlist.description,
-                    playlist.imageUri,
-                    playlist.idList.toList().remove(trackId).toString(),
-                    playlist.idList.size-1
-                )
-            )
+            val updatedIdList = playlist.idList.toMutableList().apply { remove(trackId) }
+            val playlistDto = PlaylistDto().map(playlist.copy(idList = updatedIdList, tracksCount = updatedIdList.size))
+            appDatabase.playlistDao().updatePlaylist(playlistDbConvertor.map(playlistDto))
             checkTrackInPlaylists(trackId)
         }
     }

--- a/app/src/main/java/com/practicum/playlistmaker/playlist/ui/PlaylistViewModel.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/playlist/ui/PlaylistViewModel.kt
@@ -1,7 +1,6 @@
 package com.practicum.playlistmaker.playlist.ui
 
 import android.app.Application
-import android.icu.text.SimpleDateFormat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -16,8 +15,6 @@ import com.practicum.playlistmaker.util.SingleLiveEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Locale
-
 class PlaylistViewModel(
     application: Application,
     private val playlistInteractor: PlaylistInteractor,
@@ -61,7 +58,7 @@ class PlaylistViewModel(
         for (track in trackList) {
             duration += track.trackTime.toLong()
         }
-        return SimpleDateFormat("mm", Locale.getDefault()).format(duration).toInt()
+        return (duration / 60000).toInt()
     }
 
     fun deleteTrack(trackId: String) {

--- a/app/src/main/java/com/practicum/playlistmaker/search/data/TracksHistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/data/TracksHistoryRepositoryImpl.kt
@@ -46,21 +46,16 @@ class TracksHistoryRepositoryImpl(
         prefs.edit().clear().apply()
     }
 
-    override fun addTrackToHistory(track: Track) {
-        val tracklist = mutableListOf<Track>()
-        GlobalScope.launch {
-            withContext(Dispatchers.IO) {
-                getItems()
-                    .collect { tracks ->
-                        tracklist.addAll(tracks)
-                        if (track in tracklist) {
-                            tracklist.remove(track)
-                        }
-                    }
+    override suspend fun addTrackToHistory(track: Track) {
+        val tracklist = withContext(Dispatchers.IO) {
+            val tracks = getItemsFromCache().toMutableList()
+            if (track in tracks) {
+                tracks.remove(track)
             }
-            tracklist.add(0, track)
-            saveTracklist(prefs, tracklist)
+            tracks.add(0, track)
+            tracks
         }
+        saveTracklist(prefs, tracklist)
     }
 
 

--- a/app/src/main/java/com/practicum/playlistmaker/search/domain/TracksHistoryInteractor.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/domain/TracksHistoryInteractor.kt
@@ -6,6 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface TracksHistoryInteractor {
     fun getItems(): Flow<MutableList<Track>>
     fun clearHistory()
-    fun addTrackToHistory(track: Track)
+    suspend fun addTrackToHistory(track: Track)
     fun getTrack(): Track
 }

--- a/app/src/main/java/com/practicum/playlistmaker/search/domain/TracksHistoryInteractorImpl.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/domain/TracksHistoryInteractorImpl.kt
@@ -13,7 +13,7 @@ class TracksHistoryInteractorImpl(private val repository: TracksHistoryRepositor
         repository.clearHistory()
     }
 
-    override fun addTrackToHistory(track: Track) {
+    override suspend fun addTrackToHistory(track: Track) {
         repository.addTrackToHistory(track)
     }
 

--- a/app/src/main/java/com/practicum/playlistmaker/search/domain/TracksHistoryRepository.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/domain/TracksHistoryRepository.kt
@@ -5,6 +5,6 @@ import kotlinx.coroutines.flow.Flow
 interface TracksHistoryRepository {
     fun getItems(): Flow<MutableList<Track>>
     fun clearHistory()
-    fun addTrackToHistory(track: Track)
+    suspend fun addTrackToHistory(track: Track)
     fun getTrackFromIntent(): Track
 }


### PR DESCRIPTION
Closes #25

- Fix deleteTrackFromPlaylist JSON serialization (was using List.toString())
- Replace GlobalScope.launch with suspend fun in TracksHistoryRepositoryImpl
- Fix getDurationOfTracklist to use arithmetic instead of SimpleDateFormat